### PR TITLE
Couple of changes

### DIFF
--- a/libs/clear_cache.php
+++ b/libs/clear_cache.php
@@ -34,7 +34,16 @@ class ClearCache {
 	function engines() {
 		$result = array();
 
-		$keys = Cache::configured();
+		if (method_exists('Cache', 'configured')) {
+			$keys = Cache::configured();
+		} else {
+			if (PHP5) {
+				$Cache = Cache::getInstance();
+			} else {
+				$Cache =& Cache::getInstance();
+			}
+			$keys = array_keys($Cache->__config);
+		}
 
 		if ($engines = func_get_args()) {
 			$keys = array_intersect($keys, $engines);

--- a/libs/clear_cache.php
+++ b/libs/clear_cache.php
@@ -84,6 +84,14 @@ class ClearCache {
 				} else {
 					$error[] = $file;
 				}
+			} elseif(is_dir($file)) {
+				$results = $this->files(substr($file, strlen(CACHE)));
+				$deleted = am($deleted, $results['deleted']);
+				$error = am($error, $results['error']);
+				unset($results);
+				if (!in_array($file, array(CACHE . './models', CACHE . './persistent', CACHE . './views'))) {
+					rmdir($file);
+				}
 			}
 		}
 		return compact('deleted', 'error');

--- a/libs/clear_cache.php
+++ b/libs/clear_cache.php
@@ -86,8 +86,8 @@ class ClearCache {
 				}
 			} elseif(is_dir($file)) {
 				$results = $this->files(substr($file, strlen(CACHE)));
-				$deleted = am($deleted, $results['deleted']);
-				$error = am($error, $results['error']);
+				$deleted = array_merge($deleted, $results['deleted']);
+				$error = array_merge($error, $results['error']);
 				unset($results);
 				if (!in_array($file, array(CACHE . './models', CACHE . './persistent', CACHE . './views'))) {
 					rmdir($file);

--- a/libs/clear_cache.php
+++ b/libs/clear_cache.php
@@ -5,7 +5,7 @@
  * PHP versions 4 and 5
  *
  * Copyright 2010, Marc Ypes, The Netherlands
- * 
+ *
  * Licensed under The MIT License
  * Redistributions of files must retain the above copyright notice.
  *
@@ -104,8 +104,8 @@ class ClearCache {
  * @access public
  */
 	function run() {
-		$files = $this->files();
 		$engines = $this->engines();
+		$files = $this->files();
 
 		return compact('files', 'engines');
 	}


### PR DESCRIPTION
- Backward compatibility with CakePHP 1.2
- Recursive clean the cache without removing core cache dirs (CACHE/models, CACHE/persistent, CACHE/views)
- Changing order in run() - clear cache engines first, then files (fixed some issue in File class)
